### PR TITLE
Fix sending g7 readings to watch

### DIFF
--- a/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/ListenerService.java
@@ -2416,8 +2416,8 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                                     changed = true;
                                     bgData.save();
                                 } else {
-                                    if (bgData.source_info != null && bgData.source_info.contains("Native")) {
-                                        UserError.Log.d(TAG, "Saving BgData without calibration as source info is native");
+                                    if (bgData.source_info != null && (bgData.source_info.contains("Native") || bgData.source_info.contains("G7"))) {
+                                        UserError.Log.d(TAG, "Saving BgData without calibration as no calibration is available, source info is native");
                                         bgData.sensor = sensor;
                                         bgData.sensor_uuid = sensor.uuid;
                                         changed = true;


### PR DESCRIPTION
It looks like G7 readings have no calibrations. I'm not entirely sure how calibrations/readings work for the different hardware, but when trying to connect xdrip+ to a new watch, all I get is NULL and the watch has logs with the format
`syncBGData new BgReading calibrationUuid not found by uuid; cannot save!`.

My hardware source is G5/G6/G7/1 Transmitter as I only use xDrip+ with my G7 (no dexcom app).